### PR TITLE
Fixed ring buffer test indentation error

### DIFF
--- a/ring_buffer/test_ring_buffer.py
+++ b/ring_buffer/test_ring_buffer.py
@@ -1,6 +1,7 @@
 import unittest
 from ring_buffer import RingBuffer
 
+
 class RingBufferTests(unittest.TestCase):
     def setUp(self):
         self.buffer = RingBuffer(5)
@@ -29,14 +30,14 @@ class RingBufferTests(unittest.TestCase):
         self.buffer.append('i')
         self.assertEqual(len(self.buffer.storage), 5)
         self.assertEqual(self.buffer.get(), ['f', 'g', 'h', 'i', 'e'])
-        
+
         self.buffer.append('j')
         self.buffer.append('k')
         self.assertEqual(self.buffer.get(), ['k', 'g', 'h', 'i', 'j'])
-        
+
         for i in range(50):
             self.buffer_2.append(i)
-            self.assertEqual(self.buffer_2.get(), [45, 46, 47, 48, 49])
+        self.assertEqual(self.buffer_2.get(), [45, 46, 47, 48, 49])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reduced indentation level of line 39/40 to stop it from firing within the for loop, which caused a false test failure.